### PR TITLE
Heat recipes improvements

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: unreleased
+Date: unreleased
+  Features:
+    - Auto-Recipe Algorithm keywords can be left empty to match any recipe.
+---------------------------------------------------------------------------------------------------
 Version: 1.3.21
 Date: 2023-07-23
   Changes:

--- a/info.json
+++ b/info.json
@@ -13,6 +13,19 @@
     "(?) space-exploration",
     "(?) space-exploration-postprocess",
     "(?) informatron",
+    "(?) bismuth",
+    "(?) bzaluminum",
+    "(?) bzcarbon",
+    "(?) bzchlorine",
+    "(?) bzfoundry",
+    "(?) bzgas",
+    "(?) bzgold",
+    "(?) bzlead",
+    "(?) bzsilicon",
+    "(?) bztin",
+    "(?) bztitanium",
+    "(?) bztungsten",
+    "(?) bzzirconium",
     "(?) AbandonedRuins"
   ]
 }

--- a/locale/en/base.cfg
+++ b/locale/en/base.cfg
@@ -166,7 +166,7 @@ ao-complexity-level=Experience with Atomic Overhaul: Full provides all features,
 thorium-wrd=Changes the normal reprocessing recipe to yield research data from it. However, this unlocks a technology and a recipe that do not generate research data.
 old-graphite-fuel=Brings back the old graphite fuel & processing (like it was before v.1.3.0)
 heat-algo-mode=[color=red]Warning: Wont work if [font=default-bold]Old graphite fuel[/font] is enabled![/color] \n[font=default-bold]Off[/font]: No addional heat-furnace recipes will be generated. \n[font=default-bold]Basic[/font]: Every Smelting recipe which outputs some kind of plate will be copied and added. \n[font=default-bold]Advanced[/font] (Default): Every Smelting recipe where an ore will be smelted into a plate will be copied and added.
-heat-algo-searchterm=[color=red]Warning: Wont work if [font=default-bold]Old graphite fuel[/font] is enabled![/color] \nKeywords the algo should look for when going through all recipes. \nDivide the keywords via comma and space. \n For example: plate, brick
+heat-algo-searchterm=[color=red]Warning: Wont work if [font=default-bold]Old graphite fuel[/font] is enabled![/color] \nKeywords the algo should look for when going through all recipes. \nDivide the keywords via comma and space. \nLeave empty to match everything.\n For example: plate, brick
 ao-breeder=[color=red]Simplified complexity is required and Nuclear Fuel mod should be unloaded[/color] \nReplaces Kovarex recipe with Breeder concept: special fuel cell and special Nuclear Reactor to breed fissile Plutonium isotopes.
 heat-accumulator=Disable this if you have problems with lag spikes!
 

--- a/prototypes/items/graphite.lua
+++ b/prototypes/items/graphite.lua
@@ -1,4 +1,5 @@
-if settings.startup["ao-complexity-level"].value ~= "simple" then
+if settings.startup["ao-complexity-level"].value ~= "simple" and
+    not data.raw.item["graphite"] then
   data:extend(
     {
       {

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -108,12 +108,10 @@ if ao_debug then
     log("Keywords: " .. serpent.block(searchterms))
 end
 
-if settings.startup["heat-algo-mode"].value == "advanced" then
-    if ao_debug then
+if ao_debug then
+    if settings.startup["heat-algo-mode"].value == "advanced" then
         log("Advanced Heat Algorithm")
-    end
-elseif settings.startup["heat-algo-mode"].value == "basic" then
-    if ao_debug then
+    elseif settings.startup["heat-algo-mode"].value == "basic" then
         log("Basic Heat Algorithm Mode")
     end
 end

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -69,17 +69,13 @@ if ao_debug then
     log("\n\n\n---AO: Auto-Recipe generation started---")
 end
 
-for _, recipe in pairs(testrecipes) do
-    if data.raw.recipe[recipe] then
-        if data.raw.recipe[recipe].category then
-            if data.raw["recipe"][recipe].category ~= "crafting" then
-                cc = data.raw.recipe[recipe].category
-                if ao_debug then
-                    log("Found category " .. cc)
-                end
-                break
-            end
+for _, recipename in pairs(testrecipes) do
+    if data.raw.recipe[recipename] and data.raw.recipe[recipename].category and data.raw.recipe[recipename].category ~= "crafting" then
+        cc = data.raw.recipe[recipename].category
+        if ao_debug then
+            log("Found category " .. cc)
         end
+        break
     end
 end
 

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -96,7 +96,7 @@ if settings.startup["heat-algo-mode"].value == "advanced" then
             if recipeProductMatchesSearchterms(recipe, searchterms) then
                 if recipe.ingredients then
                     for _, resource in pairs(data.raw["resource"]) do
-                        if resource.minable.result then
+                        if resource.minable and resource.minable.result then
                             for _, ingredient in pairs(recipe.ingredients) do
                                 if ingredient[1] == resource.minable.result then
                                     local newRecipe = deriveNewHeatRecipe(recipe)

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -8,12 +8,11 @@ local function deriveNewHeatRecipe(recipe)
     newRecipe.category = "heat-furnace"
     newRecipe.hidden = false
     local isunlockedbytech = false
-    for k4, tech in pairs(data.raw["technology"]) do
+    for _, tech in pairs(data.raw["technology"]) do
         if tech.effects then
-            for k5, effect in pairs(tech.effects) do
+            for _, effect in pairs(tech.effects) do
                 if effect.recipe == recipe.name then
-                    table.insert(data.raw["technology"][tech.name].effects
-                        ,
+                    table.insert(tech.effects,
                         { type = "unlock-recipe", recipe = newRecipe.name })
                     isunlockedbytech = true
                 end
@@ -21,11 +20,7 @@ local function deriveNewHeatRecipe(recipe)
             end
         end
     end
-    if isunlockedbytech == false then
-        newRecipe.enabled = true
-    else
-        newRecipe.enabled = false
-    end
+    newRecipe.enabled = not isunlockedbytech
     return newRecipe
 end
 

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -6,21 +6,17 @@ local function deriveNewHeatRecipe(recipe)
     local newRecipe = table.deepcopy(recipe)
     newRecipe.name = recipe.name .. "-heat"
     newRecipe.category = "heat-furnace"
-    newRecipe.hidden = false
-    local isunlockedbytech = false
     for _, tech in pairs(data.raw["technology"]) do
         if tech.effects then
             for _, effect in pairs(tech.effects) do
                 if effect.type == "unlock-recipe" and effect.recipe == recipe.name then
                     table.insert(tech.effects,
                         { type = "unlock-recipe", recipe = newRecipe.name })
-                    isunlockedbytech = true
                 end
 
             end
         end
     end
-    newRecipe.enabled = not isunlockedbytech
     return newRecipe
 end
 

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -120,18 +120,17 @@ end
 
 
 for _, recipe in pairs(data.raw["recipe"]) do
-    if recipe.category == cc then
-        if recipeProductMatchesSearchterms(recipe, searchterms) then
-            if (settings.startup["heat-algo-mode"].value == "basic") or
-                    (settings.startup["heat-algo-mode"].value == "advanced" and recipeHasMinableIngredient(recipe)) then
-                local newRecipe = deriveNewHeatRecipe(recipe)
-                if ao_debug then
-                    log("Copied Smelting Recipe: " .. newRecipe.name)
-                end
-                --data:extend({ newRecipe })
-                table.insert(exports, newRecipe)
-            end
+    if recipe.category == cc and
+            recipeProductMatchesSearchterms(recipe, searchterms) and (
+                (settings.startup["heat-algo-mode"].value == "basic") or
+                (settings.startup["heat-algo-mode"].value == "advanced" and recipeHasMinableIngredient(recipe))
+            ) then
+        local newRecipe = deriveNewHeatRecipe(recipe)
+        if ao_debug then
+            log("Copied Smelting Recipe: " .. newRecipe.name)
         end
+        --data:extend({ newRecipe })
+        table.insert(exports, newRecipe)
     end
 end
 

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -58,16 +58,16 @@ local function recipeProductMatchesSearchterms(recipe, searchterms)
         )
 end
 
--- Returns true if the recipe contains at least one minable ingredient
--- otherwise false.
+-- ``recipeData`` is a Recipe Data; most commonly the ``recipe`` itself or
+-- ``recipe.normal`` or ``recipe.expensive``.
 --
--- Returns false if ``recipe`` is nil.
-local function recipeHasMinableIngredient(recipe)
-    if not recipe or not recipe.ingredients then
+-- Returns false if ``recipeData`` is nil
+local function recipeDataHasMinableIngredient(recipeData)
+    if not recipeData or not recipeData.ingredients then
         return false
     end
 
-    for _, ingredient in pairs(recipe.ingredients) do
+    for _, ingredient in pairs(recipeData.ingredients) do
         for _, resource in pairs(data.raw["resource"]) do
             if resource.minable then
                 if resource.minable.result then
@@ -101,6 +101,19 @@ local function recipeHasMinableIngredient(recipe)
     end
 
     return false
+end
+
+-- Returns true if the recipe contains at least one minable ingredient
+-- otherwise false.
+--
+-- Returns false if ``recipe`` is nil.
+local function recipeHasMinableIngredient(recipe)
+    return
+        recipe and (
+            recipeDataHasMinableIngredient(recipe.normal) or
+            recipeDataHasMinableIngredient(recipe.expensive) or
+            recipeDataHasMinableIngredient(recipe)
+        )
 end
 
 

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -1,262 +1,52 @@
-if settings.startup["heat-algo-mode"] ~= "off" then
-    local cc = nil
-    local exports = {}
-    local setting_searchterms = settings.startup["heat-algo-searchterm"].value
-    local searchterms = {}
-    local testrecipes = { "iron-plate", "copper-plate", "stone-brick", "angelsore1-crushed-smelting" }
+if settings.startup["heat-algo-mode"] == "off" then
+    return
+end
 
-    if ao_debug then
-        log("\n\n\n---AO: Auto-Recipe generation started---")
-    end
+local cc = nil
+local exports = {}
+local setting_searchterms = settings.startup["heat-algo-searchterm"].value
+local searchterms = {}
+local testrecipes = { "iron-plate", "copper-plate", "stone-brick", "angelsore1-crushed-smelting" }
 
-    for _, recipe in pairs(testrecipes) do
-        if data.raw.recipe[recipe] then
-            if data.raw.recipe[recipe].category then
-                if data.raw["recipe"][recipe].category ~= "crafting" then
-                    cc = data.raw.recipe[recipe].category
-                    if ao_debug then
-                        log("Found category " .. cc)
-                    end
-                    break
+if ao_debug then
+    log("\n\n\n---AO: Auto-Recipe generation started---")
+end
+
+for _, recipe in pairs(testrecipes) do
+    if data.raw.recipe[recipe] then
+        if data.raw.recipe[recipe].category then
+            if data.raw["recipe"][recipe].category ~= "crafting" then
+                cc = data.raw.recipe[recipe].category
+                if ao_debug then
+                    log("Found category " .. cc)
                 end
+                break
             end
         end
     end
+end
 
-    for word in string.gmatch(setting_searchterms, '([^, ]+)') do
-        table.insert(searchterms, word)
-    end
+for word in string.gmatch(setting_searchterms, '([^, ]+)') do
+    table.insert(searchterms, word)
+end
+if ao_debug then
+    log("Keywords: " .. serpent.block(searchterms))
+end
+
+if settings.startup["heat-algo-mode"].value == "advanced" then
     if ao_debug then
-        log("Keywords: " .. serpent.block(searchterms))
+        log("Advanced Heat Algorithm")
     end
 
-    if settings.startup["heat-algo-mode"].value == "advanced" then
-        if ao_debug then
-            log("Advanced Heat Algorithm")
-        end
-
-        for k, resource in pairs(data.raw["resource"]) do
-            if resource.minable.result then
-                for k2, recipe in pairs(data.raw["recipe"]) do
-                    if data.raw["recipe"][recipe.name].category == cc then
-                        if data.raw["recipe"][recipe.name].ingredients then
-                            for k3, ingredient in pairs(data.raw["recipe"][recipe.name].ingredients) do
-                                if ingredient[1] == data.raw["resource"][resource.name].minable.result then
-                                    if data.raw["recipe"][recipe.name].normal then
-                                        if data.raw["recipe"][recipe.name].normal.result then
-                                            for _, i in pairs(searchterms) do
-                                                if recipe.result:find(i) then
-                                                    local newRecipe = table.deepcopy(recipe)
-                                                    newRecipe.name = recipe.name .. "-heat"
-                                                    newRecipe.category = "heat-furnace"
-                                                    newRecipe.hidden = false
-                                                    local isunlockedbytech = false
-                                                    for k4, tech in pairs(data.raw["technology"]) do
-                                                        if tech.effects then
-                                                            for k5, effect in pairs(tech.effects) do
-                                                                if effect.recipe == recipe.name then
-                                                                    table.insert(data.raw["technology"][tech.name].effects
-                                                                        ,
-                                                                        { type = "unlock-recipe", recipe = newRecipe.name })
-                                                                    isunlockedbytech = true
-                                                                end
-
-                                                            end
-                                                        end
-                                                    end
-                                                    if isunlockedbytech == false then
-                                                        newRecipe.enabled = true
-                                                    else
-                                                        newRecipe.enabled = false
-                                                    end
-                                                    if ao_debug then
-                                                        log("Copied Smelting Recipe: " .. newRecipe.name)
-                                                    end
-                                                    --data:extend({ newRecipe })
-                                                    table.insert(exports, newRecipe)
-                                                end
-                                            end
-                                        elseif data.raw["recipe"][recipe.name].normal.results then
-                                            for k4, result in pairs(data.raw["recipe"][recipe.name].results) do
-                                                for _, i in pairs(searchterms) do
-                                                    if result[1] then
-                                                        if result[1]:find(i) then
-                                                            local newRecipe = table.deepcopy(recipe)
-                                                            newRecipe.name = recipe.name .. "-heat"
-                                                            newRecipe.category = "heat-furnace"
-                                                            newRecipe.hidden = false
-                                                            local isunlockedbytech = false
-                                                            for k4, tech in pairs(data.raw["technology"]) do
-                                                                if tech.effects then
-                                                                    for k5, effect in pairs(tech.effects) do
-                                                                        if effect.recipe == recipe.name then
-                                                                            table.insert(data.raw["technology"][
-                                                                                tech.name].effects
-                                                                                ,
-                                                                                { type = "unlock-recipe",
-                                                                                    recipe = newRecipe.name })
-                                                                            isunlockedbytech = true
-                                                                        end
-
-                                                                    end
-                                                                end
-                                                            end
-                                                            if isunlockedbytech == false then
-                                                                newRecipe.enabled = true
-                                                            else
-                                                                newRecipe.enabled = false
-                                                            end
-                                                            if ao_debug then
-                                                                log("Copied Smelting Recipe: " .. newRecipe.name)
-                                                            end
-                                                            --data:extend({ newRecipe })
-                                                            table.insert(exports, newRecipe)
-                                                        end
-                                                    elseif result.name then
-                                                        if result.name:find(i) then
-                                                            local newRecipe = table.deepcopy(recipe)
-                                                            newRecipe.name = recipe.name .. "-heat"
-                                                            newRecipe.category = "heat-furnace"
-                                                            newRecipe.hidden = false
-                                                            local isunlockedbytech = false
-                                                            for k4, tech in pairs(data.raw["technology"]) do
-                                                                if tech.effects then
-                                                                    for k5, effect in pairs(tech.effects) do
-                                                                        if effect.recipe == recipe.name then
-                                                                            table.insert(data.raw["technology"][
-                                                                                tech.name].effects
-                                                                                ,
-                                                                                { type = "unlock-recipe",
-                                                                                    recipe = newRecipe.name })
-                                                                            isunlockedbytech = true
-                                                                        end
-
-                                                                    end
-                                                                end
-                                                            end
-                                                            if isunlockedbytech == false then
-                                                                newRecipe.enabled = true
-                                                            else
-                                                                newRecipe.enabled = false
-                                                            end
-                                                            if ao_debug then
-                                                                log("Copied Smelting Recipe: " .. newRecipe.name)
-                                                            end
-                                                            --data:extend({ newRecipe })
-                                                            table.insert(exports, newRecipe)
-                                                        end
-                                                    end
-                                                end
-                                            end
-                                        end
-                                    elseif data.raw["recipe"][recipe.name].expensive then
-                                        if data.raw["recipe"][recipe.name].expensive.result then
-                                            for _, i in pairs(searchterms) do
-                                                if recipe.result:find(i) then
-                                                    local newRecipe = table.deepcopy(recipe)
-                                                    newRecipe.name = recipe.name .. "-heat"
-                                                    newRecipe.category = "heat-furnace"
-                                                    newRecipe.hidden = false
-                                                    local isunlockedbytech = false
-                                                    for k4, tech in pairs(data.raw["technology"]) do
-                                                        if tech.effects then
-                                                            for k5, effect in pairs(tech.effects) do
-                                                                if effect.recipe == recipe.name then
-                                                                    table.insert(data.raw["technology"][tech.name].effects
-                                                                        ,
-                                                                        { type = "unlock-recipe", recipe = newRecipe.name })
-                                                                    isunlockedbytech = true
-                                                                end
-
-                                                            end
-                                                        end
-                                                    end
-                                                    if isunlockedbytech == false then
-                                                        newRecipe.enabled = true
-                                                    else
-                                                        newRecipe.enabled = false
-                                                    end
-                                                    if ao_debug then
-                                                        log("Copied Smelting Recipe: " .. newRecipe.name)
-                                                    end
-                                                    --data:extend({ newRecipe })
-                                                    table.insert(exports, newRecipe)
-                                                end
-                                            end
-                                        elseif data.raw["recipe"][recipe.name].expensive.results then
-                                            for k4, result in pairs(data.raw["recipe"][recipe.name].results) do
-                                                for _, i in pairs(searchterms) do
-                                                    if result[1] then
-                                                        if result[1]:find(i) then
-                                                            local newRecipe = table.deepcopy(recipe)
-                                                            newRecipe.name = recipe.name .. "-heat"
-                                                            newRecipe.category = "heat-furnace"
-                                                            newRecipe.hidden = false
-                                                            local isunlockedbytech = false
-                                                            for k4, tech in pairs(data.raw["technology"]) do
-                                                                if tech.effects then
-                                                                    for k5, effect in pairs(tech.effects) do
-                                                                        if effect.recipe == recipe.name then
-                                                                            table.insert(data.raw["technology"][
-                                                                                tech.name].effects
-                                                                                ,
-                                                                                { type = "unlock-recipe",
-                                                                                    recipe = newRecipe.name })
-                                                                            isunlockedbytech = true
-                                                                        end
-
-                                                                    end
-                                                                end
-                                                            end
-                                                            if isunlockedbytech == false then
-                                                                newRecipe.enabled = true
-                                                            else
-                                                                newRecipe.enabled = false
-                                                            end
-                                                            if ao_debug then
-                                                                log("Copied Smelting Recipe: " .. newRecipe.name)
-                                                            end
-                                                            --data:extend({ newRecipe })
-                                                            table.insert(exports, newRecipe)
-                                                        end
-                                                    elseif result.name then
-                                                        if result.name:find(i) then
-                                                            local newRecipe = table.deepcopy(recipe)
-                                                            newRecipe.name = recipe.name .. "-heat"
-                                                            newRecipe.category = "heat-furnace"
-                                                            newRecipe.hidden = false
-                                                            local isunlockedbytech = false
-                                                            for k4, tech in pairs(data.raw["technology"]) do
-                                                                if tech.effects then
-                                                                    for k5, effect in pairs(tech.effects) do
-                                                                        if effect.recipe == recipe.name then
-                                                                            table.insert(data.raw["technology"][
-                                                                                tech.name].effects
-                                                                                ,
-                                                                                { type = "unlock-recipe",
-                                                                                    recipe = newRecipe.name })
-                                                                            isunlockedbytech = true
-                                                                        end
-
-                                                                    end
-                                                                end
-                                                            end
-                                                            if isunlockedbytech == false then
-                                                                newRecipe.enabled = true
-                                                            else
-                                                                newRecipe.enabled = false
-                                                            end
-                                                            if ao_debug then
-                                                                log("Copied Smelting Recipe: " .. newRecipe.name)
-                                                            end
-                                                            --data:extend({ newRecipe })
-                                                            table.insert(exports, newRecipe)
-                                                        end
-                                                    end
-                                                end
-                                            end
-                                        end
-                                    elseif data.raw["recipe"][recipe.name].result then
+    for k, resource in pairs(data.raw["resource"]) do
+        if resource.minable.result then
+            for k2, recipe in pairs(data.raw["recipe"]) do
+                if data.raw["recipe"][recipe.name].category == cc then
+                    if data.raw["recipe"][recipe.name].ingredients then
+                        for k3, ingredient in pairs(data.raw["recipe"][recipe.name].ingredients) do
+                            if ingredient[1] == data.raw["resource"][resource.name].minable.result then
+                                if data.raw["recipe"][recipe.name].normal then
+                                    if data.raw["recipe"][recipe.name].normal.result then
                                         for _, i in pairs(searchterms) do
                                             if recipe.result:find(i) then
                                                 local newRecipe = table.deepcopy(recipe)
@@ -268,7 +58,8 @@ if settings.startup["heat-algo-mode"] ~= "off" then
                                                     if tech.effects then
                                                         for k5, effect in pairs(tech.effects) do
                                                             if effect.recipe == recipe.name then
-                                                                table.insert(data.raw["technology"][tech.name].effects,
+                                                                table.insert(data.raw["technology"][tech.name].effects
+                                                                    ,
                                                                     { type = "unlock-recipe", recipe = newRecipe.name })
                                                                 isunlockedbytech = true
                                                             end
@@ -288,7 +79,7 @@ if settings.startup["heat-algo-mode"] ~= "off" then
                                                 table.insert(exports, newRecipe)
                                             end
                                         end
-                                    elseif data.raw["recipe"][recipe.name].results then
+                                    elseif data.raw["recipe"][recipe.name].normal.results then
                                         for k4, result in pairs(data.raw["recipe"][recipe.name].results) do
                                             for _, i in pairs(searchterms) do
                                                 if result[1] then
@@ -302,7 +93,8 @@ if settings.startup["heat-algo-mode"] ~= "off" then
                                                             if tech.effects then
                                                                 for k5, effect in pairs(tech.effects) do
                                                                     if effect.recipe == recipe.name then
-                                                                        table.insert(data.raw["technology"][tech.name].effects
+                                                                        table.insert(data.raw["technology"][
+                                                                            tech.name].effects
                                                                             ,
                                                                             { type = "unlock-recipe",
                                                                                 recipe = newRecipe.name })
@@ -334,7 +126,8 @@ if settings.startup["heat-algo-mode"] ~= "off" then
                                                             if tech.effects then
                                                                 for k5, effect in pairs(tech.effects) do
                                                                     if effect.recipe == recipe.name then
-                                                                        table.insert(data.raw["technology"][tech.name].effects
+                                                                        table.insert(data.raw["technology"][
+                                                                            tech.name].effects
                                                                             ,
                                                                             { type = "unlock-recipe",
                                                                                 recipe = newRecipe.name })
@@ -359,6 +152,215 @@ if settings.startup["heat-algo-mode"] ~= "off" then
                                             end
                                         end
                                     end
+                                elseif data.raw["recipe"][recipe.name].expensive then
+                                    if data.raw["recipe"][recipe.name].expensive.result then
+                                        for _, i in pairs(searchterms) do
+                                            if recipe.result:find(i) then
+                                                local newRecipe = table.deepcopy(recipe)
+                                                newRecipe.name = recipe.name .. "-heat"
+                                                newRecipe.category = "heat-furnace"
+                                                newRecipe.hidden = false
+                                                local isunlockedbytech = false
+                                                for k4, tech in pairs(data.raw["technology"]) do
+                                                    if tech.effects then
+                                                        for k5, effect in pairs(tech.effects) do
+                                                            if effect.recipe == recipe.name then
+                                                                table.insert(data.raw["technology"][tech.name].effects
+                                                                    ,
+                                                                    { type = "unlock-recipe", recipe = newRecipe.name })
+                                                                isunlockedbytech = true
+                                                            end
+
+                                                        end
+                                                    end
+                                                end
+                                                if isunlockedbytech == false then
+                                                    newRecipe.enabled = true
+                                                else
+                                                    newRecipe.enabled = false
+                                                end
+                                                if ao_debug then
+                                                    log("Copied Smelting Recipe: " .. newRecipe.name)
+                                                end
+                                                --data:extend({ newRecipe })
+                                                table.insert(exports, newRecipe)
+                                            end
+                                        end
+                                    elseif data.raw["recipe"][recipe.name].expensive.results then
+                                        for k4, result in pairs(data.raw["recipe"][recipe.name].results) do
+                                            for _, i in pairs(searchterms) do
+                                                if result[1] then
+                                                    if result[1]:find(i) then
+                                                        local newRecipe = table.deepcopy(recipe)
+                                                        newRecipe.name = recipe.name .. "-heat"
+                                                        newRecipe.category = "heat-furnace"
+                                                        newRecipe.hidden = false
+                                                        local isunlockedbytech = false
+                                                        for k4, tech in pairs(data.raw["technology"]) do
+                                                            if tech.effects then
+                                                                for k5, effect in pairs(tech.effects) do
+                                                                    if effect.recipe == recipe.name then
+                                                                        table.insert(data.raw["technology"][
+                                                                            tech.name].effects
+                                                                            ,
+                                                                            { type = "unlock-recipe",
+                                                                                recipe = newRecipe.name })
+                                                                        isunlockedbytech = true
+                                                                    end
+
+                                                                end
+                                                            end
+                                                        end
+                                                        if isunlockedbytech == false then
+                                                            newRecipe.enabled = true
+                                                        else
+                                                            newRecipe.enabled = false
+                                                        end
+                                                        if ao_debug then
+                                                            log("Copied Smelting Recipe: " .. newRecipe.name)
+                                                        end
+                                                        --data:extend({ newRecipe })
+                                                        table.insert(exports, newRecipe)
+                                                    end
+                                                elseif result.name then
+                                                    if result.name:find(i) then
+                                                        local newRecipe = table.deepcopy(recipe)
+                                                        newRecipe.name = recipe.name .. "-heat"
+                                                        newRecipe.category = "heat-furnace"
+                                                        newRecipe.hidden = false
+                                                        local isunlockedbytech = false
+                                                        for k4, tech in pairs(data.raw["technology"]) do
+                                                            if tech.effects then
+                                                                for k5, effect in pairs(tech.effects) do
+                                                                    if effect.recipe == recipe.name then
+                                                                        table.insert(data.raw["technology"][
+                                                                            tech.name].effects
+                                                                            ,
+                                                                            { type = "unlock-recipe",
+                                                                                recipe = newRecipe.name })
+                                                                        isunlockedbytech = true
+                                                                    end
+
+                                                                end
+                                                            end
+                                                        end
+                                                        if isunlockedbytech == false then
+                                                            newRecipe.enabled = true
+                                                        else
+                                                            newRecipe.enabled = false
+                                                        end
+                                                        if ao_debug then
+                                                            log("Copied Smelting Recipe: " .. newRecipe.name)
+                                                        end
+                                                        --data:extend({ newRecipe })
+                                                        table.insert(exports, newRecipe)
+                                                    end
+                                                end
+                                            end
+                                        end
+                                    end
+                                elseif data.raw["recipe"][recipe.name].result then
+                                    for _, i in pairs(searchterms) do
+                                        if recipe.result:find(i) then
+                                            local newRecipe = table.deepcopy(recipe)
+                                            newRecipe.name = recipe.name .. "-heat"
+                                            newRecipe.category = "heat-furnace"
+                                            newRecipe.hidden = false
+                                            local isunlockedbytech = false
+                                            for k4, tech in pairs(data.raw["technology"]) do
+                                                if tech.effects then
+                                                    for k5, effect in pairs(tech.effects) do
+                                                        if effect.recipe == recipe.name then
+                                                            table.insert(data.raw["technology"][tech.name].effects,
+                                                                { type = "unlock-recipe", recipe = newRecipe.name })
+                                                            isunlockedbytech = true
+                                                        end
+
+                                                    end
+                                                end
+                                            end
+                                            if isunlockedbytech == false then
+                                                newRecipe.enabled = true
+                                            else
+                                                newRecipe.enabled = false
+                                            end
+                                            if ao_debug then
+                                                log("Copied Smelting Recipe: " .. newRecipe.name)
+                                            end
+                                            --data:extend({ newRecipe })
+                                            table.insert(exports, newRecipe)
+                                        end
+                                    end
+                                elseif data.raw["recipe"][recipe.name].results then
+                                    for k4, result in pairs(data.raw["recipe"][recipe.name].results) do
+                                        for _, i in pairs(searchterms) do
+                                            if result[1] then
+                                                if result[1]:find(i) then
+                                                    local newRecipe = table.deepcopy(recipe)
+                                                    newRecipe.name = recipe.name .. "-heat"
+                                                    newRecipe.category = "heat-furnace"
+                                                    newRecipe.hidden = false
+                                                    local isunlockedbytech = false
+                                                    for k4, tech in pairs(data.raw["technology"]) do
+                                                        if tech.effects then
+                                                            for k5, effect in pairs(tech.effects) do
+                                                                if effect.recipe == recipe.name then
+                                                                    table.insert(data.raw["technology"][tech.name].effects
+                                                                        ,
+                                                                        { type = "unlock-recipe",
+                                                                            recipe = newRecipe.name })
+                                                                    isunlockedbytech = true
+                                                                end
+
+                                                            end
+                                                        end
+                                                    end
+                                                    if isunlockedbytech == false then
+                                                        newRecipe.enabled = true
+                                                    else
+                                                        newRecipe.enabled = false
+                                                    end
+                                                    if ao_debug then
+                                                        log("Copied Smelting Recipe: " .. newRecipe.name)
+                                                    end
+                                                    --data:extend({ newRecipe })
+                                                    table.insert(exports, newRecipe)
+                                                end
+                                            elseif result.name then
+                                                if result.name:find(i) then
+                                                    local newRecipe = table.deepcopy(recipe)
+                                                    newRecipe.name = recipe.name .. "-heat"
+                                                    newRecipe.category = "heat-furnace"
+                                                    newRecipe.hidden = false
+                                                    local isunlockedbytech = false
+                                                    for k4, tech in pairs(data.raw["technology"]) do
+                                                        if tech.effects then
+                                                            for k5, effect in pairs(tech.effects) do
+                                                                if effect.recipe == recipe.name then
+                                                                    table.insert(data.raw["technology"][tech.name].effects
+                                                                        ,
+                                                                        { type = "unlock-recipe",
+                                                                            recipe = newRecipe.name })
+                                                                    isunlockedbytech = true
+                                                                end
+
+                                                            end
+                                                        end
+                                                    end
+                                                    if isunlockedbytech == false then
+                                                        newRecipe.enabled = true
+                                                    else
+                                                        newRecipe.enabled = false
+                                                    end
+                                                    if ao_debug then
+                                                        log("Copied Smelting Recipe: " .. newRecipe.name)
+                                                    end
+                                                    --data:extend({ newRecipe })
+                                                    table.insert(exports, newRecipe)
+                                                end
+                                            end
+                                        end
+                                    end
                                 end
                             end
                         end
@@ -366,117 +368,20 @@ if settings.startup["heat-algo-mode"] ~= "off" then
                 end
             end
         end
+    end
 
 
-    elseif settings.startup["heat-algo-mode"].value == "basic" then
-        if ao_debug then
-            log("Basic Heat Algorithm Mode")
-        end
+elseif settings.startup["heat-algo-mode"].value == "basic" then
+    if ao_debug then
+        log("Basic Heat Algorithm Mode")
+    end
 
-        for k2, recipe in pairs(data.raw["recipe"]) do
-            if data.raw["recipe"][recipe.name].category == cc then
-                if data.raw["recipe"][recipe.name].normal then
-                    if data.raw["recipe"][recipe.name].normal.result then
-                        for _, i in pairs(searchterms) do
-                            if recipe.normal.result:find(i) then
-                                local newRecipe = table.deepcopy(recipe)
-                                newRecipe.name = recipe.name .. "-heat"
-                                newRecipe.category = "heat-furnace"
-                                newRecipe.hidden = false
-                                local isunlockedbytech = false
-                                for k4, tech in pairs(data.raw["technology"]) do
-                                    if tech.effects then
-                                        for k5, effect in pairs(tech.effects) do
-                                            if effect.recipe == recipe.name then
-                                                table.insert(data.raw["technology"][tech.name].effects,
-                                                    { type = "unlock-recipe", recipe = newRecipe.name })
-                                                isunlockedbytech = true
-                                            end
-                                        end
-                                    end
-                                end
-                                if isunlockedbytech == false then
-                                    newRecipe.enabled = true
-                                else
-                                    newRecipe.enabled = false
-                                end
-                                if ao_debug then
-                                    log("Copied Smelting Recipe: " .. newRecipe.name)
-                                end
-                                --data:extend({ newRecipe })
-                                table.insert(exports, newRecipe)
-                            end
-                        end
-                    elseif data.raw["recipe"][recipe.name].normal.results then
-                        for k4, result in pairs(data.raw["recipe"][recipe.name].normal.results) do
-                            for _, i in pairs(searchterms) do
-                                if result[1] then
-                                    if result[1]:find(i) then
-                                        local newRecipe = table.deepcopy(recipe)
-                                        newRecipe.name = recipe.name .. "-heat"
-                                        newRecipe.category = "heat-furnace"
-                                        newRecipe.hidden = false
-                                        local isunlockedbytech = false
-                                        for k4, tech in pairs(data.raw["technology"]) do
-                                            if tech.effects then
-                                                for k5, effect in pairs(tech.effects) do
-                                                    if effect.recipe == recipe.name then
-                                                        table.insert(data.raw["technology"][tech.name].effects,
-                                                            { type = "unlock-recipe", recipe = newRecipe.name })
-                                                        isunlockedbytech = true
-                                                    end
-                                                end
-
-                                            end
-                                        end
-                                        if isunlockedbytech == false then
-                                            newRecipe.enabled = true
-                                        else
-                                            newRecipe.enabled = false
-                                        end
-                                        if ao_debug then
-                                            log("Copied Smelting Recipe: " .. newRecipe.name)
-                                        end
-                                        --data:extend({ newRecipe })
-                                        table.insert(exports, newRecipe)
-                                    end
-                                elseif result.name then
-                                    if result.name:find(i) then
-                                        local newRecipe = table.deepcopy(recipe)
-                                        newRecipe.name = recipe.name .. "-heat"
-                                        newRecipe.category = "heat-furnace"
-                                        newRecipe.hidden = false
-                                        local isunlockedbytech = false
-                                        for k4, tech in pairs(data.raw["technology"]) do
-                                            if tech.effects then
-                                                for k5, effect in pairs(tech.effects) do
-                                                    if effect.recipe == recipe.name then
-                                                        table.insert(data.raw["technology"][tech.name].effects,
-                                                            { type = "unlock-recipe", recipe = newRecipe.name })
-                                                        isunlockedbytech = true
-                                                    end
-                                                end
-
-                                            end
-                                        end
-                                        if isunlockedbytech == false then
-                                            newRecipe.enabled = true
-                                        else
-                                            newRecipe.enabled = false
-                                        end
-                                        if ao_debug then
-                                            log("Copied Smelting Recipe: " .. newRecipe.name)
-                                        end
-                                        --data:extend({ newRecipe })
-                                        table.insert(exports, newRecipe)
-                                    end
-                                end
-                            end
-                        end
-                    end
-                elseif data.raw["recipe"][recipe.name].result then
+    for k2, recipe in pairs(data.raw["recipe"]) do
+        if data.raw["recipe"][recipe.name].category == cc then
+            if data.raw["recipe"][recipe.name].normal then
+                if data.raw["recipe"][recipe.name].normal.result then
                     for _, i in pairs(searchterms) do
-                        if recipe.result:find(i) then
+                        if recipe.normal.result:find(i) then
                             local newRecipe = table.deepcopy(recipe)
                             newRecipe.name = recipe.name .. "-heat"
                             newRecipe.category = "heat-furnace"
@@ -505,8 +410,8 @@ if settings.startup["heat-algo-mode"] ~= "off" then
                             table.insert(exports, newRecipe)
                         end
                     end
-                elseif data.raw["recipe"][recipe.name].results then
-                    for k4, result in pairs(data.raw["recipe"][recipe.name].results) do
+                elseif data.raw["recipe"][recipe.name].normal.results then
+                    for k4, result in pairs(data.raw["recipe"][recipe.name].normal.results) do
                         for _, i in pairs(searchterms) do
                             if result[1] then
                                 if result[1]:find(i) then
@@ -572,18 +477,114 @@ if settings.startup["heat-algo-mode"] ~= "off" then
                         end
                     end
                 end
+            elseif data.raw["recipe"][recipe.name].result then
+                for _, i in pairs(searchterms) do
+                    if recipe.result:find(i) then
+                        local newRecipe = table.deepcopy(recipe)
+                        newRecipe.name = recipe.name .. "-heat"
+                        newRecipe.category = "heat-furnace"
+                        newRecipe.hidden = false
+                        local isunlockedbytech = false
+                        for k4, tech in pairs(data.raw["technology"]) do
+                            if tech.effects then
+                                for k5, effect in pairs(tech.effects) do
+                                    if effect.recipe == recipe.name then
+                                        table.insert(data.raw["technology"][tech.name].effects,
+                                            { type = "unlock-recipe", recipe = newRecipe.name })
+                                        isunlockedbytech = true
+                                    end
+                                end
+                            end
+                        end
+                        if isunlockedbytech == false then
+                            newRecipe.enabled = true
+                        else
+                            newRecipe.enabled = false
+                        end
+                        if ao_debug then
+                            log("Copied Smelting Recipe: " .. newRecipe.name)
+                        end
+                        --data:extend({ newRecipe })
+                        table.insert(exports, newRecipe)
+                    end
+                end
+            elseif data.raw["recipe"][recipe.name].results then
+                for k4, result in pairs(data.raw["recipe"][recipe.name].results) do
+                    for _, i in pairs(searchterms) do
+                        if result[1] then
+                            if result[1]:find(i) then
+                                local newRecipe = table.deepcopy(recipe)
+                                newRecipe.name = recipe.name .. "-heat"
+                                newRecipe.category = "heat-furnace"
+                                newRecipe.hidden = false
+                                local isunlockedbytech = false
+                                for k4, tech in pairs(data.raw["technology"]) do
+                                    if tech.effects then
+                                        for k5, effect in pairs(tech.effects) do
+                                            if effect.recipe == recipe.name then
+                                                table.insert(data.raw["technology"][tech.name].effects,
+                                                    { type = "unlock-recipe", recipe = newRecipe.name })
+                                                isunlockedbytech = true
+                                            end
+                                        end
+
+                                    end
+                                end
+                                if isunlockedbytech == false then
+                                    newRecipe.enabled = true
+                                else
+                                    newRecipe.enabled = false
+                                end
+                                if ao_debug then
+                                    log("Copied Smelting Recipe: " .. newRecipe.name)
+                                end
+                                --data:extend({ newRecipe })
+                                table.insert(exports, newRecipe)
+                            end
+                        elseif result.name then
+                            if result.name:find(i) then
+                                local newRecipe = table.deepcopy(recipe)
+                                newRecipe.name = recipe.name .. "-heat"
+                                newRecipe.category = "heat-furnace"
+                                newRecipe.hidden = false
+                                local isunlockedbytech = false
+                                for k4, tech in pairs(data.raw["technology"]) do
+                                    if tech.effects then
+                                        for k5, effect in pairs(tech.effects) do
+                                            if effect.recipe == recipe.name then
+                                                table.insert(data.raw["technology"][tech.name].effects,
+                                                    { type = "unlock-recipe", recipe = newRecipe.name })
+                                                isunlockedbytech = true
+                                            end
+                                        end
+
+                                    end
+                                end
+                                if isunlockedbytech == false then
+                                    newRecipe.enabled = true
+                                else
+                                    newRecipe.enabled = false
+                                end
+                                if ao_debug then
+                                    log("Copied Smelting Recipe: " .. newRecipe.name)
+                                end
+                                --data:extend({ newRecipe })
+                                table.insert(exports, newRecipe)
+                            end
+                        end
+                    end
+                end
             end
         end
-
     end
 
+end
 
-    if ao_debug then
-        log("All Exports: \n" .. serpent.block(exports) .. "\n")
-        log("AO: Auto-Recipe generation complete\n\n\n")
-    end
-    for _, recipe in pairs(exports) do
-        data:extend({ recipe })
-    end
 
+if ao_debug then
+    log("All Exports: \n" .. serpent.block(exports) .. "\n")
+    log("AO: Auto-Recipe generation complete\n\n\n")
+end
+for _, recipe in pairs(exports) do
+    data:extend({ recipe })
 end

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -67,9 +67,9 @@ local function recipeHasMinableIngredient(recipe)
         return false
     end
 
-    for _, resource in pairs(data.raw["resource"]) do
-        if resource.minable and resource.minable.result then
-            for _, ingredient in pairs(recipe.ingredients) do
+    for _, ingredient in pairs(recipe.ingredients) do
+        for _, resource in pairs(data.raw["resource"]) do
+            if resource.minable and resource.minable.result then
                 if ingredient[1] == resource.minable.result then
                     return true
                 end

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -24,12 +24,12 @@ local function recipeProductMatchesSearchterms(recipe, searchterms)
     if data.raw["recipe"][recipe.name].normal then
         if data.raw["recipe"][recipe.name].normal.result then
             for _, i in pairs(searchterms) do
-                if recipe.result:find(i) then
+                if recipe.normal.result:find(i) then
                     return true
                 end
             end
         elseif data.raw["recipe"][recipe.name].normal.results then
-            for k4, result in pairs(data.raw["recipe"][recipe.name].results) do
+            for k4, result in pairs(data.raw["recipe"][recipe.name].normal.results) do
                 for _, i in pairs(searchterms) do
                     if result[1] then
                         if result[1]:find(i) then
@@ -46,12 +46,12 @@ local function recipeProductMatchesSearchterms(recipe, searchterms)
     elseif data.raw["recipe"][recipe.name].expensive then
         if data.raw["recipe"][recipe.name].expensive.result then
             for _, i in pairs(searchterms) do
-                if recipe.result:find(i) then
+                if recipe.expensive.result:find(i) then
                     return true
                 end
             end
         elseif data.raw["recipe"][recipe.name].expensive.results then
-            for k4, result in pairs(data.raw["recipe"][recipe.name].results) do
+            for k4, result in pairs(data.raw["recipe"][recipe.name].expensive.results) do
                 for _, i in pairs(searchterms) do
                     if result[1] then
                         if result[1]:find(i) then

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -137,11 +137,19 @@ for _, recipename in pairs(testrecipes) do
     end
 end
 
-for word in string.gmatch(setting_searchterms, '([^, ]+)') do
-    table.insert(searchterms, word)
-end
-if ao_debug then
-    log("Keywords: " .. serpent.block(searchterms))
+if setting_searchterms == "" then
+    -- empty word matches everything
+    table.insert(searchterms, "")
+    if ao_debug then
+        log("Keywords: No keywords")
+    end
+else
+    for word in string.gmatch(setting_searchterms, '([^, ]+)') do
+        table.insert(searchterms, word)
+    end
+    if ao_debug then
+        log("Keywords: " .. serpent.block(searchterms))
+    end
 end
 
 if ao_debug then

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -91,14 +91,14 @@ if settings.startup["heat-algo-mode"].value == "advanced" then
         log("Advanced Heat Algorithm")
     end
 
-    for _, resource in pairs(data.raw["resource"]) do
-        if resource.minable.result then
-            for _, recipe in pairs(data.raw["recipe"]) do
-                if recipe.category == cc then
-                    if recipe.ingredients then
-                        for _, ingredient in pairs(recipe.ingredients) do
-                            if ingredient[1] == resource.minable.result then
-                                if recipeProductMatchesSearchterms(recipe, searchterms) then
+    for _, recipe in pairs(data.raw["recipe"]) do
+        if recipe.category == cc then
+            if recipeProductMatchesSearchterms(recipe, searchterms) then
+                if recipe.ingredients then
+                    for _, resource in pairs(data.raw["resource"]) do
+                        if resource.minable.result then
+                            for _, ingredient in pairs(recipe.ingredients) do
+                                if ingredient[1] == resource.minable.result then
                                     local newRecipe = deriveNewHeatRecipe(recipe)
                                     if ao_debug then
                                         log("Copied Smelting Recipe: " .. newRecipe.name)

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -90,10 +90,24 @@ if settings.startup["heat-algo-mode"].value == "advanced" then
     if ao_debug then
         log("Advanced Heat Algorithm")
     end
+elseif settings.startup["heat-algo-mode"].value == "basic" then
+    if ao_debug then
+        log("Basic Heat Algorithm Mode")
+    end
+end
 
-    for _, recipe in pairs(data.raw["recipe"]) do
-        if recipe.category == cc then
-            if recipeProductMatchesSearchterms(recipe, searchterms) then
+
+for _, recipe in pairs(data.raw["recipe"]) do
+    if recipe.category == cc then
+        if recipeProductMatchesSearchterms(recipe, searchterms) then
+            if settings.startup["heat-algo-mode"].value == "basic" then
+                local newRecipe = deriveNewHeatRecipe(recipe)
+                if ao_debug then
+                    log("Copied Smelting Recipe: " .. newRecipe.name)
+                end
+                --data:extend({ newRecipe })
+                table.insert(exports, newRecipe)
+            elseif settings.startup["heat-algo-mode"].value == "advanced" then
                 if recipe.ingredients then
                     for _, resource in pairs(data.raw["resource"]) do
                         if resource.minable and resource.minable.result then
@@ -113,26 +127,6 @@ if settings.startup["heat-algo-mode"].value == "advanced" then
             end
         end
     end
-
-
-elseif settings.startup["heat-algo-mode"].value == "basic" then
-    if ao_debug then
-        log("Basic Heat Algorithm Mode")
-    end
-
-    for _, recipe in pairs(data.raw["recipe"]) do
-        if recipe.category == cc then
-            if recipeProductMatchesSearchterms(recipe, searchterms) then
-                local newRecipe = deriveNewHeatRecipe(recipe)
-                if ao_debug then
-                    log("Copied Smelting Recipe: " .. newRecipe.name)
-                end
-                --data:extend({ newRecipe })
-                table.insert(exports, newRecipe)
-            end
-        end
-    end
-
 end
 
 

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -2,6 +2,33 @@ if settings.startup["heat-algo-mode"] == "off" then
     return
 end
 
+local function deriveNewHeatRecipe(recipe)
+    local newRecipe = table.deepcopy(recipe)
+    newRecipe.name = recipe.name .. "-heat"
+    newRecipe.category = "heat-furnace"
+    newRecipe.hidden = false
+    local isunlockedbytech = false
+    for k4, tech in pairs(data.raw["technology"]) do
+        if tech.effects then
+            for k5, effect in pairs(tech.effects) do
+                if effect.recipe == recipe.name then
+                    table.insert(data.raw["technology"][tech.name].effects
+                        ,
+                        { type = "unlock-recipe", recipe = newRecipe.name })
+                    isunlockedbytech = true
+                end
+
+            end
+        end
+    end
+    if isunlockedbytech == false then
+        newRecipe.enabled = true
+    else
+        newRecipe.enabled = false
+    end
+    return newRecipe
+end
+
 local cc = nil
 local exports = {}
 local setting_searchterms = settings.startup["heat-algo-searchterm"].value
@@ -49,29 +76,7 @@ if settings.startup["heat-algo-mode"].value == "advanced" then
                                     if data.raw["recipe"][recipe.name].normal.result then
                                         for _, i in pairs(searchterms) do
                                             if recipe.result:find(i) then
-                                                local newRecipe = table.deepcopy(recipe)
-                                                newRecipe.name = recipe.name .. "-heat"
-                                                newRecipe.category = "heat-furnace"
-                                                newRecipe.hidden = false
-                                                local isunlockedbytech = false
-                                                for k4, tech in pairs(data.raw["technology"]) do
-                                                    if tech.effects then
-                                                        for k5, effect in pairs(tech.effects) do
-                                                            if effect.recipe == recipe.name then
-                                                                table.insert(data.raw["technology"][tech.name].effects
-                                                                    ,
-                                                                    { type = "unlock-recipe", recipe = newRecipe.name })
-                                                                isunlockedbytech = true
-                                                            end
-
-                                                        end
-                                                    end
-                                                end
-                                                if isunlockedbytech == false then
-                                                    newRecipe.enabled = true
-                                                else
-                                                    newRecipe.enabled = false
-                                                end
+                                                local newRecipe = deriveNewHeatRecipe(recipe)
                                                 if ao_debug then
                                                     log("Copied Smelting Recipe: " .. newRecipe.name)
                                                 end
@@ -84,31 +89,7 @@ if settings.startup["heat-algo-mode"].value == "advanced" then
                                             for _, i in pairs(searchterms) do
                                                 if result[1] then
                                                     if result[1]:find(i) then
-                                                        local newRecipe = table.deepcopy(recipe)
-                                                        newRecipe.name = recipe.name .. "-heat"
-                                                        newRecipe.category = "heat-furnace"
-                                                        newRecipe.hidden = false
-                                                        local isunlockedbytech = false
-                                                        for k4, tech in pairs(data.raw["technology"]) do
-                                                            if tech.effects then
-                                                                for k5, effect in pairs(tech.effects) do
-                                                                    if effect.recipe == recipe.name then
-                                                                        table.insert(data.raw["technology"][
-                                                                            tech.name].effects
-                                                                            ,
-                                                                            { type = "unlock-recipe",
-                                                                                recipe = newRecipe.name })
-                                                                        isunlockedbytech = true
-                                                                    end
-
-                                                                end
-                                                            end
-                                                        end
-                                                        if isunlockedbytech == false then
-                                                            newRecipe.enabled = true
-                                                        else
-                                                            newRecipe.enabled = false
-                                                        end
+                                                        local newRecipe = deriveNewHeatRecipe(recipe)
                                                         if ao_debug then
                                                             log("Copied Smelting Recipe: " .. newRecipe.name)
                                                         end
@@ -117,31 +98,7 @@ if settings.startup["heat-algo-mode"].value == "advanced" then
                                                     end
                                                 elseif result.name then
                                                     if result.name:find(i) then
-                                                        local newRecipe = table.deepcopy(recipe)
-                                                        newRecipe.name = recipe.name .. "-heat"
-                                                        newRecipe.category = "heat-furnace"
-                                                        newRecipe.hidden = false
-                                                        local isunlockedbytech = false
-                                                        for k4, tech in pairs(data.raw["technology"]) do
-                                                            if tech.effects then
-                                                                for k5, effect in pairs(tech.effects) do
-                                                                    if effect.recipe == recipe.name then
-                                                                        table.insert(data.raw["technology"][
-                                                                            tech.name].effects
-                                                                            ,
-                                                                            { type = "unlock-recipe",
-                                                                                recipe = newRecipe.name })
-                                                                        isunlockedbytech = true
-                                                                    end
-
-                                                                end
-                                                            end
-                                                        end
-                                                        if isunlockedbytech == false then
-                                                            newRecipe.enabled = true
-                                                        else
-                                                            newRecipe.enabled = false
-                                                        end
+                                                        local newRecipe = deriveNewHeatRecipe(recipe)
                                                         if ao_debug then
                                                             log("Copied Smelting Recipe: " .. newRecipe.name)
                                                         end
@@ -156,29 +113,7 @@ if settings.startup["heat-algo-mode"].value == "advanced" then
                                     if data.raw["recipe"][recipe.name].expensive.result then
                                         for _, i in pairs(searchterms) do
                                             if recipe.result:find(i) then
-                                                local newRecipe = table.deepcopy(recipe)
-                                                newRecipe.name = recipe.name .. "-heat"
-                                                newRecipe.category = "heat-furnace"
-                                                newRecipe.hidden = false
-                                                local isunlockedbytech = false
-                                                for k4, tech in pairs(data.raw["technology"]) do
-                                                    if tech.effects then
-                                                        for k5, effect in pairs(tech.effects) do
-                                                            if effect.recipe == recipe.name then
-                                                                table.insert(data.raw["technology"][tech.name].effects
-                                                                    ,
-                                                                    { type = "unlock-recipe", recipe = newRecipe.name })
-                                                                isunlockedbytech = true
-                                                            end
-
-                                                        end
-                                                    end
-                                                end
-                                                if isunlockedbytech == false then
-                                                    newRecipe.enabled = true
-                                                else
-                                                    newRecipe.enabled = false
-                                                end
+                                                local newRecipe = deriveNewHeatRecipe(recipe)
                                                 if ao_debug then
                                                     log("Copied Smelting Recipe: " .. newRecipe.name)
                                                 end
@@ -191,31 +126,7 @@ if settings.startup["heat-algo-mode"].value == "advanced" then
                                             for _, i in pairs(searchterms) do
                                                 if result[1] then
                                                     if result[1]:find(i) then
-                                                        local newRecipe = table.deepcopy(recipe)
-                                                        newRecipe.name = recipe.name .. "-heat"
-                                                        newRecipe.category = "heat-furnace"
-                                                        newRecipe.hidden = false
-                                                        local isunlockedbytech = false
-                                                        for k4, tech in pairs(data.raw["technology"]) do
-                                                            if tech.effects then
-                                                                for k5, effect in pairs(tech.effects) do
-                                                                    if effect.recipe == recipe.name then
-                                                                        table.insert(data.raw["technology"][
-                                                                            tech.name].effects
-                                                                            ,
-                                                                            { type = "unlock-recipe",
-                                                                                recipe = newRecipe.name })
-                                                                        isunlockedbytech = true
-                                                                    end
-
-                                                                end
-                                                            end
-                                                        end
-                                                        if isunlockedbytech == false then
-                                                            newRecipe.enabled = true
-                                                        else
-                                                            newRecipe.enabled = false
-                                                        end
+                                                        local newRecipe = deriveNewHeatRecipe(recipe)
                                                         if ao_debug then
                                                             log("Copied Smelting Recipe: " .. newRecipe.name)
                                                         end
@@ -224,31 +135,7 @@ if settings.startup["heat-algo-mode"].value == "advanced" then
                                                     end
                                                 elseif result.name then
                                                     if result.name:find(i) then
-                                                        local newRecipe = table.deepcopy(recipe)
-                                                        newRecipe.name = recipe.name .. "-heat"
-                                                        newRecipe.category = "heat-furnace"
-                                                        newRecipe.hidden = false
-                                                        local isunlockedbytech = false
-                                                        for k4, tech in pairs(data.raw["technology"]) do
-                                                            if tech.effects then
-                                                                for k5, effect in pairs(tech.effects) do
-                                                                    if effect.recipe == recipe.name then
-                                                                        table.insert(data.raw["technology"][
-                                                                            tech.name].effects
-                                                                            ,
-                                                                            { type = "unlock-recipe",
-                                                                                recipe = newRecipe.name })
-                                                                        isunlockedbytech = true
-                                                                    end
-
-                                                                end
-                                                            end
-                                                        end
-                                                        if isunlockedbytech == false then
-                                                            newRecipe.enabled = true
-                                                        else
-                                                            newRecipe.enabled = false
-                                                        end
+                                                        local newRecipe = deriveNewHeatRecipe(recipe)
                                                         if ao_debug then
                                                             log("Copied Smelting Recipe: " .. newRecipe.name)
                                                         end
@@ -262,28 +149,7 @@ if settings.startup["heat-algo-mode"].value == "advanced" then
                                 elseif data.raw["recipe"][recipe.name].result then
                                     for _, i in pairs(searchterms) do
                                         if recipe.result:find(i) then
-                                            local newRecipe = table.deepcopy(recipe)
-                                            newRecipe.name = recipe.name .. "-heat"
-                                            newRecipe.category = "heat-furnace"
-                                            newRecipe.hidden = false
-                                            local isunlockedbytech = false
-                                            for k4, tech in pairs(data.raw["technology"]) do
-                                                if tech.effects then
-                                                    for k5, effect in pairs(tech.effects) do
-                                                        if effect.recipe == recipe.name then
-                                                            table.insert(data.raw["technology"][tech.name].effects,
-                                                                { type = "unlock-recipe", recipe = newRecipe.name })
-                                                            isunlockedbytech = true
-                                                        end
-
-                                                    end
-                                                end
-                                            end
-                                            if isunlockedbytech == false then
-                                                newRecipe.enabled = true
-                                            else
-                                                newRecipe.enabled = false
-                                            end
+                                            local newRecipe = deriveNewHeatRecipe(recipe)
                                             if ao_debug then
                                                 log("Copied Smelting Recipe: " .. newRecipe.name)
                                             end
@@ -296,30 +162,7 @@ if settings.startup["heat-algo-mode"].value == "advanced" then
                                         for _, i in pairs(searchterms) do
                                             if result[1] then
                                                 if result[1]:find(i) then
-                                                    local newRecipe = table.deepcopy(recipe)
-                                                    newRecipe.name = recipe.name .. "-heat"
-                                                    newRecipe.category = "heat-furnace"
-                                                    newRecipe.hidden = false
-                                                    local isunlockedbytech = false
-                                                    for k4, tech in pairs(data.raw["technology"]) do
-                                                        if tech.effects then
-                                                            for k5, effect in pairs(tech.effects) do
-                                                                if effect.recipe == recipe.name then
-                                                                    table.insert(data.raw["technology"][tech.name].effects
-                                                                        ,
-                                                                        { type = "unlock-recipe",
-                                                                            recipe = newRecipe.name })
-                                                                    isunlockedbytech = true
-                                                                end
-
-                                                            end
-                                                        end
-                                                    end
-                                                    if isunlockedbytech == false then
-                                                        newRecipe.enabled = true
-                                                    else
-                                                        newRecipe.enabled = false
-                                                    end
+                                                    local newRecipe = deriveNewHeatRecipe(recipe)
                                                     if ao_debug then
                                                         log("Copied Smelting Recipe: " .. newRecipe.name)
                                                     end
@@ -328,30 +171,7 @@ if settings.startup["heat-algo-mode"].value == "advanced" then
                                                 end
                                             elseif result.name then
                                                 if result.name:find(i) then
-                                                    local newRecipe = table.deepcopy(recipe)
-                                                    newRecipe.name = recipe.name .. "-heat"
-                                                    newRecipe.category = "heat-furnace"
-                                                    newRecipe.hidden = false
-                                                    local isunlockedbytech = false
-                                                    for k4, tech in pairs(data.raw["technology"]) do
-                                                        if tech.effects then
-                                                            for k5, effect in pairs(tech.effects) do
-                                                                if effect.recipe == recipe.name then
-                                                                    table.insert(data.raw["technology"][tech.name].effects
-                                                                        ,
-                                                                        { type = "unlock-recipe",
-                                                                            recipe = newRecipe.name })
-                                                                    isunlockedbytech = true
-                                                                end
-
-                                                            end
-                                                        end
-                                                    end
-                                                    if isunlockedbytech == false then
-                                                        newRecipe.enabled = true
-                                                    else
-                                                        newRecipe.enabled = false
-                                                    end
+                                                    local newRecipe = deriveNewHeatRecipe(recipe)
                                                     if ao_debug then
                                                         log("Copied Smelting Recipe: " .. newRecipe.name)
                                                     end
@@ -382,27 +202,7 @@ elseif settings.startup["heat-algo-mode"].value == "basic" then
                 if data.raw["recipe"][recipe.name].normal.result then
                     for _, i in pairs(searchterms) do
                         if recipe.normal.result:find(i) then
-                            local newRecipe = table.deepcopy(recipe)
-                            newRecipe.name = recipe.name .. "-heat"
-                            newRecipe.category = "heat-furnace"
-                            newRecipe.hidden = false
-                            local isunlockedbytech = false
-                            for k4, tech in pairs(data.raw["technology"]) do
-                                if tech.effects then
-                                    for k5, effect in pairs(tech.effects) do
-                                        if effect.recipe == recipe.name then
-                                            table.insert(data.raw["technology"][tech.name].effects,
-                                                { type = "unlock-recipe", recipe = newRecipe.name })
-                                            isunlockedbytech = true
-                                        end
-                                    end
-                                end
-                            end
-                            if isunlockedbytech == false then
-                                newRecipe.enabled = true
-                            else
-                                newRecipe.enabled = false
-                            end
+                            local newRecipe = deriveNewHeatRecipe(recipe)
                             if ao_debug then
                                 log("Copied Smelting Recipe: " .. newRecipe.name)
                             end
@@ -415,28 +215,7 @@ elseif settings.startup["heat-algo-mode"].value == "basic" then
                         for _, i in pairs(searchterms) do
                             if result[1] then
                                 if result[1]:find(i) then
-                                    local newRecipe = table.deepcopy(recipe)
-                                    newRecipe.name = recipe.name .. "-heat"
-                                    newRecipe.category = "heat-furnace"
-                                    newRecipe.hidden = false
-                                    local isunlockedbytech = false
-                                    for k4, tech in pairs(data.raw["technology"]) do
-                                        if tech.effects then
-                                            for k5, effect in pairs(tech.effects) do
-                                                if effect.recipe == recipe.name then
-                                                    table.insert(data.raw["technology"][tech.name].effects,
-                                                        { type = "unlock-recipe", recipe = newRecipe.name })
-                                                    isunlockedbytech = true
-                                                end
-                                            end
-
-                                        end
-                                    end
-                                    if isunlockedbytech == false then
-                                        newRecipe.enabled = true
-                                    else
-                                        newRecipe.enabled = false
-                                    end
+                                    local newRecipe = deriveNewHeatRecipe(recipe)
                                     if ao_debug then
                                         log("Copied Smelting Recipe: " .. newRecipe.name)
                                     end
@@ -445,28 +224,7 @@ elseif settings.startup["heat-algo-mode"].value == "basic" then
                                 end
                             elseif result.name then
                                 if result.name:find(i) then
-                                    local newRecipe = table.deepcopy(recipe)
-                                    newRecipe.name = recipe.name .. "-heat"
-                                    newRecipe.category = "heat-furnace"
-                                    newRecipe.hidden = false
-                                    local isunlockedbytech = false
-                                    for k4, tech in pairs(data.raw["technology"]) do
-                                        if tech.effects then
-                                            for k5, effect in pairs(tech.effects) do
-                                                if effect.recipe == recipe.name then
-                                                    table.insert(data.raw["technology"][tech.name].effects,
-                                                        { type = "unlock-recipe", recipe = newRecipe.name })
-                                                    isunlockedbytech = true
-                                                end
-                                            end
-
-                                        end
-                                    end
-                                    if isunlockedbytech == false then
-                                        newRecipe.enabled = true
-                                    else
-                                        newRecipe.enabled = false
-                                    end
+                                    local newRecipe = deriveNewHeatRecipe(recipe)
                                     if ao_debug then
                                         log("Copied Smelting Recipe: " .. newRecipe.name)
                                     end
@@ -480,27 +238,7 @@ elseif settings.startup["heat-algo-mode"].value == "basic" then
             elseif data.raw["recipe"][recipe.name].result then
                 for _, i in pairs(searchterms) do
                     if recipe.result:find(i) then
-                        local newRecipe = table.deepcopy(recipe)
-                        newRecipe.name = recipe.name .. "-heat"
-                        newRecipe.category = "heat-furnace"
-                        newRecipe.hidden = false
-                        local isunlockedbytech = false
-                        for k4, tech in pairs(data.raw["technology"]) do
-                            if tech.effects then
-                                for k5, effect in pairs(tech.effects) do
-                                    if effect.recipe == recipe.name then
-                                        table.insert(data.raw["technology"][tech.name].effects,
-                                            { type = "unlock-recipe", recipe = newRecipe.name })
-                                        isunlockedbytech = true
-                                    end
-                                end
-                            end
-                        end
-                        if isunlockedbytech == false then
-                            newRecipe.enabled = true
-                        else
-                            newRecipe.enabled = false
-                        end
+                        local newRecipe = deriveNewHeatRecipe(recipe)
                         if ao_debug then
                             log("Copied Smelting Recipe: " .. newRecipe.name)
                         end
@@ -513,28 +251,7 @@ elseif settings.startup["heat-algo-mode"].value == "basic" then
                     for _, i in pairs(searchterms) do
                         if result[1] then
                             if result[1]:find(i) then
-                                local newRecipe = table.deepcopy(recipe)
-                                newRecipe.name = recipe.name .. "-heat"
-                                newRecipe.category = "heat-furnace"
-                                newRecipe.hidden = false
-                                local isunlockedbytech = false
-                                for k4, tech in pairs(data.raw["technology"]) do
-                                    if tech.effects then
-                                        for k5, effect in pairs(tech.effects) do
-                                            if effect.recipe == recipe.name then
-                                                table.insert(data.raw["technology"][tech.name].effects,
-                                                    { type = "unlock-recipe", recipe = newRecipe.name })
-                                                isunlockedbytech = true
-                                            end
-                                        end
-
-                                    end
-                                end
-                                if isunlockedbytech == false then
-                                    newRecipe.enabled = true
-                                else
-                                    newRecipe.enabled = false
-                                end
+                                local newRecipe = deriveNewHeatRecipe(recipe)
                                 if ao_debug then
                                     log("Copied Smelting Recipe: " .. newRecipe.name)
                                 end
@@ -543,28 +260,7 @@ elseif settings.startup["heat-algo-mode"].value == "basic" then
                             end
                         elseif result.name then
                             if result.name:find(i) then
-                                local newRecipe = table.deepcopy(recipe)
-                                newRecipe.name = recipe.name .. "-heat"
-                                newRecipe.category = "heat-furnace"
-                                newRecipe.hidden = false
-                                local isunlockedbytech = false
-                                for k4, tech in pairs(data.raw["technology"]) do
-                                    if tech.effects then
-                                        for k5, effect in pairs(tech.effects) do
-                                            if effect.recipe == recipe.name then
-                                                table.insert(data.raw["technology"][tech.name].effects,
-                                                    { type = "unlock-recipe", recipe = newRecipe.name })
-                                                isunlockedbytech = true
-                                            end
-                                        end
-
-                                    end
-                                end
-                                if isunlockedbytech == false then
-                                    newRecipe.enabled = true
-                                else
-                                    newRecipe.enabled = false
-                                end
+                                local newRecipe = deriveNewHeatRecipe(recipe)
                                 if ao_debug then
                                     log("Copied Smelting Recipe: " .. newRecipe.name)
                                 end

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -21,15 +21,15 @@ local function deriveNewHeatRecipe(recipe)
 end
 
 local function recipeProductMatchesSearchterms(recipe, searchterms)
-    if data.raw["recipe"][recipe.name].normal then
-        if data.raw["recipe"][recipe.name].normal.result then
+    if recipe.normal then
+        if recipe.normal.result then
             for _, i in pairs(searchterms) do
                 if recipe.normal.result:find(i) then
                     return true
                 end
             end
-        elseif data.raw["recipe"][recipe.name].normal.results then
-            for k4, result in pairs(data.raw["recipe"][recipe.name].normal.results) do
+        elseif recipe.normal.results then
+            for k4, result in pairs(recipe.normal.results) do
                 for _, i in pairs(searchterms) do
                     if result[1] then
                         if result[1]:find(i) then
@@ -43,15 +43,15 @@ local function recipeProductMatchesSearchterms(recipe, searchterms)
                 end
             end
         end
-    elseif data.raw["recipe"][recipe.name].expensive then
-        if data.raw["recipe"][recipe.name].expensive.result then
+    elseif recipe.expensive then
+        if recipe.expensive.result then
             for _, i in pairs(searchterms) do
                 if recipe.expensive.result:find(i) then
                     return true
                 end
             end
-        elseif data.raw["recipe"][recipe.name].expensive.results then
-            for k4, result in pairs(data.raw["recipe"][recipe.name].expensive.results) do
+        elseif recipe.expensive.results then
+            for k4, result in pairs(recipe.expensive.results) do
                 for _, i in pairs(searchterms) do
                     if result[1] then
                         if result[1]:find(i) then
@@ -65,14 +65,14 @@ local function recipeProductMatchesSearchterms(recipe, searchterms)
                 end
             end
         end
-    elseif data.raw["recipe"][recipe.name].result then
+    elseif recipe.result then
         for _, i in pairs(searchterms) do
             if recipe.result:find(i) then
                 return true
             end
         end
-    elseif data.raw["recipe"][recipe.name].results then
-        for k4, result in pairs(data.raw["recipe"][recipe.name].results) do
+    elseif recipe.results then
+        for k4, result in pairs(recipe.results) do
             for _, i in pairs(searchterms) do
                 if result[1] then
                     if result[1]:find(i) then
@@ -130,10 +130,10 @@ if settings.startup["heat-algo-mode"].value == "advanced" then
     for k, resource in pairs(data.raw["resource"]) do
         if resource.minable.result then
             for k2, recipe in pairs(data.raw["recipe"]) do
-                if data.raw["recipe"][recipe.name].category == cc then
-                    if data.raw["recipe"][recipe.name].ingredients then
-                        for k3, ingredient in pairs(data.raw["recipe"][recipe.name].ingredients) do
-                            if ingredient[1] == data.raw["resource"][resource.name].minable.result then
+                if recipe.category == cc then
+                    if recipe.ingredients then
+                        for k3, ingredient in pairs(recipe.ingredients) do
+                            if ingredient[1] == resource.minable.result then
                                 if recipeProductMatchesSearchterms(recipe, searchterms) then
                                     local newRecipe = deriveNewHeatRecipe(recipe)
                                     if ao_debug then
@@ -157,7 +157,7 @@ elseif settings.startup["heat-algo-mode"].value == "basic" then
     end
 
     for k2, recipe in pairs(data.raw["recipe"]) do
-        if data.raw["recipe"][recipe.name].category == cc then
+        if recipe.category == cc then
             if recipeProductMatchesSearchterms(recipe, searchterms) then
                 local newRecipe = deriveNewHeatRecipe(recipe)
                 if ao_debug then

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -71,7 +71,8 @@ local function recipeHasMinableIngredient(recipe)
         for _, resource in pairs(data.raw["resource"]) do
             if resource.minable then
                 if resource.minable.result then
-                    if ingredient[1] == resource.minable.result then
+                    if ingredient[1] == resource.minable.result or
+                        ingredient.name == resource.minable.result then
                         return true
                     end
                 end

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -20,59 +20,23 @@ local function deriveNewHeatRecipe(recipe)
     return newRecipe
 end
 
-local function recipeProductMatchesSearchterms(recipe, searchterms)
-    if recipe.normal then
-        if recipe.normal.result then
-            for _, i in pairs(searchterms) do
-                if recipe.normal.result:find(i) then
-                    return true
-                end
-            end
-        elseif recipe.normal.results then
-            for k4, result in pairs(recipe.normal.results) do
-                for _, i in pairs(searchterms) do
-                    if result[1] then
-                        if result[1]:find(i) then
-                            return true
-                        end
-                    elseif result.name then
-                        if result.name:find(i) then
-                            return true
-                        end
-                    end
-                end
-            end
-        end
-    elseif recipe.expensive then
-        if recipe.expensive.result then
-            for _, i in pairs(searchterms) do
-                if recipe.expensive.result:find(i) then
-                    return true
-                end
-            end
-        elseif recipe.expensive.results then
-            for k4, result in pairs(recipe.expensive.results) do
-                for _, i in pairs(searchterms) do
-                    if result[1] then
-                        if result[1]:find(i) then
-                            return true
-                        end
-                    elseif result.name then
-                        if result.name:find(i) then
-                            return true
-                        end
-                    end
-                end
-            end
-        end
-    elseif recipe.result then
+-- ``recipeData`` is a Recipe Data; most commonly the ``recipe`` itself or
+-- ``recipe.normal`` or ``recipe.expensive``.
+--
+-- Returns false if ``recipeData`` is nil
+local function productMatchesSearchterms(recipeData, searchterms)
+    if not recipeData then
+        return false
+    end
+
+    if recipeData.result then
         for _, i in pairs(searchterms) do
-            if recipe.result:find(i) then
+            if recipeData.result:find(i) then
                 return true
             end
         end
-    elseif recipe.results then
-        for k4, result in pairs(recipe.results) do
+    elseif recipeData.results then
+        for k4, result in pairs(recipeData.results) do
             for _, i in pairs(searchterms) do
                 if result[1] then
                     if result[1]:find(i) then
@@ -85,6 +49,18 @@ local function recipeProductMatchesSearchterms(recipe, searchterms)
                 end
             end
         end
+    end
+
+    return false
+end
+
+local function recipeProductMatchesSearchterms(recipe, searchterms)
+    if recipe.normal then
+        return productMatchesSearchterms(recipe.normal, searchterms)
+    elseif recipe.expensive then
+        return productMatchesSearchterms(recipe.expensive, searchterms)
+    elseif recipe then
+        return productMatchesSearchterms(recipe, searchterms)
     end
 
     return false

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -58,6 +58,28 @@ local function recipeProductMatchesSearchterms(recipe, searchterms)
         )
 end
 
+-- Returns true if the recipe contains at least one minable ingredient
+-- otherwise false.
+--
+-- Returns false if ``recipe`` is nil.
+local function recipeHasMinableIngredient(recipe)
+    if not recipe or not recipe.ingredients then
+        return false
+    end
+
+    for _, resource in pairs(data.raw["resource"]) do
+        if resource.minable and resource.minable.result then
+            for _, ingredient in pairs(recipe.ingredients) do
+                if ingredient[1] == resource.minable.result then
+                    return true
+                end
+            end
+        end
+    end
+
+    return false
+end
+
 
 local cc = nil
 local exports = {}
@@ -107,23 +129,13 @@ for _, recipe in pairs(data.raw["recipe"]) do
                 end
                 --data:extend({ newRecipe })
                 table.insert(exports, newRecipe)
-            elseif settings.startup["heat-algo-mode"].value == "advanced" then
-                if recipe.ingredients then
-                    for _, resource in pairs(data.raw["resource"]) do
-                        if resource.minable and resource.minable.result then
-                            for _, ingredient in pairs(recipe.ingredients) do
-                                if ingredient[1] == resource.minable.result then
-                                    local newRecipe = deriveNewHeatRecipe(recipe)
-                                    if ao_debug then
-                                        log("Copied Smelting Recipe: " .. newRecipe.name)
-                                    end
-                                    --data:extend({ newRecipe })
-                                    table.insert(exports, newRecipe)
-                                end
-                            end
-                        end
-                    end
+            elseif settings.startup["heat-algo-mode"].value == "advanced" and recipeHasMinableIngredient(recipe) then
+                local newRecipe = deriveNewHeatRecipe(recipe)
+                if ao_debug then
+                    log("Copied Smelting Recipe: " .. newRecipe.name)
                 end
+                --data:extend({ newRecipe })
+                table.insert(exports, newRecipe)
             end
         end
     end

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -75,6 +75,26 @@ local function recipeHasMinableIngredient(recipe)
                         ingredient.name == resource.minable.result then
                         return true
                     end
+                elseif resource.minable.results then
+                    for _, result in pairs(resource.minable.results) do
+                        -- Note: We cannot compare with 2-by-2 like this:
+                        --
+                        -- > if (ingredient[1] == result[1]) or
+                        -- >     (ingredient[1] == result.name) or
+                        -- >     (ingredient.name == result[1]) or
+                        -- >     (ingredient.name == result.name) then
+                        -- >     return true
+                        -- > end
+                        --
+                        -- because one of the two entries abc[1] and abc.name
+                        -- will be nil, thus one of the four comparisons will
+                        -- result in ``nil == nil``, which is true.
+                        result_name = result[1] or result.name
+                        ingredient_name = ingredient[1] or ingredient.name
+                        if (ingredient_name == result_name) then
+                            return true
+                        end
+                    end
                 end
             end
         end

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -158,78 +158,13 @@ elseif settings.startup["heat-algo-mode"].value == "basic" then
 
     for k2, recipe in pairs(data.raw["recipe"]) do
         if data.raw["recipe"][recipe.name].category == cc then
-            if data.raw["recipe"][recipe.name].normal then
-                if data.raw["recipe"][recipe.name].normal.result then
-                    for _, i in pairs(searchterms) do
-                        if recipe.normal.result:find(i) then
-                            local newRecipe = deriveNewHeatRecipe(recipe)
-                            if ao_debug then
-                                log("Copied Smelting Recipe: " .. newRecipe.name)
-                            end
-                            --data:extend({ newRecipe })
-                            table.insert(exports, newRecipe)
-                        end
-                    end
-                elseif data.raw["recipe"][recipe.name].normal.results then
-                    for k4, result in pairs(data.raw["recipe"][recipe.name].normal.results) do
-                        for _, i in pairs(searchterms) do
-                            if result[1] then
-                                if result[1]:find(i) then
-                                    local newRecipe = deriveNewHeatRecipe(recipe)
-                                    if ao_debug then
-                                        log("Copied Smelting Recipe: " .. newRecipe.name)
-                                    end
-                                    --data:extend({ newRecipe })
-                                    table.insert(exports, newRecipe)
-                                end
-                            elseif result.name then
-                                if result.name:find(i) then
-                                    local newRecipe = deriveNewHeatRecipe(recipe)
-                                    if ao_debug then
-                                        log("Copied Smelting Recipe: " .. newRecipe.name)
-                                    end
-                                    --data:extend({ newRecipe })
-                                    table.insert(exports, newRecipe)
-                                end
-                            end
-                        end
-                    end
+            if recipeProductMatchesSearchterms(recipe, searchterms) then
+                local newRecipe = deriveNewHeatRecipe(recipe)
+                if ao_debug then
+                    log("Copied Smelting Recipe: " .. newRecipe.name)
                 end
-            elseif data.raw["recipe"][recipe.name].result then
-                for _, i in pairs(searchterms) do
-                    if recipe.result:find(i) then
-                        local newRecipe = deriveNewHeatRecipe(recipe)
-                        if ao_debug then
-                            log("Copied Smelting Recipe: " .. newRecipe.name)
-                        end
-                        --data:extend({ newRecipe })
-                        table.insert(exports, newRecipe)
-                    end
-                end
-            elseif data.raw["recipe"][recipe.name].results then
-                for k4, result in pairs(data.raw["recipe"][recipe.name].results) do
-                    for _, i in pairs(searchterms) do
-                        if result[1] then
-                            if result[1]:find(i) then
-                                local newRecipe = deriveNewHeatRecipe(recipe)
-                                if ao_debug then
-                                    log("Copied Smelting Recipe: " .. newRecipe.name)
-                                end
-                                --data:extend({ newRecipe })
-                                table.insert(exports, newRecipe)
-                            end
-                        elseif result.name then
-                            if result.name:find(i) then
-                                local newRecipe = deriveNewHeatRecipe(recipe)
-                                if ao_debug then
-                                    log("Copied Smelting Recipe: " .. newRecipe.name)
-                                end
-                                --data:extend({ newRecipe })
-                                table.insert(exports, newRecipe)
-                            end
-                        end
-                    end
-                end
+                --data:extend({ newRecipe })
+                table.insert(exports, newRecipe)
             end
         end
     end

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -69,9 +69,11 @@ local function recipeHasMinableIngredient(recipe)
 
     for _, ingredient in pairs(recipe.ingredients) do
         for _, resource in pairs(data.raw["resource"]) do
-            if resource.minable and resource.minable.result then
-                if ingredient[1] == resource.minable.result then
-                    return true
+            if resource.minable then
+                if resource.minable.result then
+                    if ingredient[1] == resource.minable.result then
+                        return true
+                    end
                 end
             end
         end

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -91,12 +91,12 @@ if settings.startup["heat-algo-mode"].value == "advanced" then
         log("Advanced Heat Algorithm")
     end
 
-    for k, resource in pairs(data.raw["resource"]) do
+    for _, resource in pairs(data.raw["resource"]) do
         if resource.minable.result then
-            for k2, recipe in pairs(data.raw["recipe"]) do
+            for _, recipe in pairs(data.raw["recipe"]) do
                 if recipe.category == cc then
                     if recipe.ingredients then
-                        for k3, ingredient in pairs(recipe.ingredients) do
+                        for _, ingredient in pairs(recipe.ingredients) do
                             if ingredient[1] == resource.minable.result then
                                 if recipeProductMatchesSearchterms(recipe, searchterms) then
                                     local newRecipe = deriveNewHeatRecipe(recipe)
@@ -120,7 +120,7 @@ elseif settings.startup["heat-algo-mode"].value == "basic" then
         log("Basic Heat Algorithm Mode")
     end
 
-    for k2, recipe in pairs(data.raw["recipe"]) do
+    for _, recipe in pairs(data.raw["recipe"]) do
         if recipe.category == cc then
             if recipeProductMatchesSearchterms(recipe, searchterms) then
                 local newRecipe = deriveNewHeatRecipe(recipe)

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -122,14 +122,8 @@ end
 for _, recipe in pairs(data.raw["recipe"]) do
     if recipe.category == cc then
         if recipeProductMatchesSearchterms(recipe, searchterms) then
-            if settings.startup["heat-algo-mode"].value == "basic" then
-                local newRecipe = deriveNewHeatRecipe(recipe)
-                if ao_debug then
-                    log("Copied Smelting Recipe: " .. newRecipe.name)
-                end
-                --data:extend({ newRecipe })
-                table.insert(exports, newRecipe)
-            elseif settings.startup["heat-algo-mode"].value == "advanced" and recipeHasMinableIngredient(recipe) then
+            if (settings.startup["heat-algo-mode"].value == "basic") or
+                    (settings.startup["heat-algo-mode"].value == "advanced" and recipeHasMinableIngredient(recipe)) then
                 local newRecipe = deriveNewHeatRecipe(recipe)
                 if ao_debug then
                     log("Copied Smelting Recipe: " .. newRecipe.name)

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -11,7 +11,7 @@ local function deriveNewHeatRecipe(recipe)
     for _, tech in pairs(data.raw["technology"]) do
         if tech.effects then
             for _, effect in pairs(tech.effects) do
-                if effect.recipe == recipe.name then
+                if effect.type == "unlock-recipe" and effect.recipe == recipe.name then
                     table.insert(tech.effects,
                         { type = "unlock-recipe", recipe = newRecipe.name })
                     isunlockedbytech = true

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -20,6 +20,77 @@ local function deriveNewHeatRecipe(recipe)
     return newRecipe
 end
 
+local function recipeProductMatchesSearchterms(recipe, searchterms)
+    if data.raw["recipe"][recipe.name].normal then
+        if data.raw["recipe"][recipe.name].normal.result then
+            for _, i in pairs(searchterms) do
+                if recipe.result:find(i) then
+                    return true
+                end
+            end
+        elseif data.raw["recipe"][recipe.name].normal.results then
+            for k4, result in pairs(data.raw["recipe"][recipe.name].results) do
+                for _, i in pairs(searchterms) do
+                    if result[1] then
+                        if result[1]:find(i) then
+                            return true
+                        end
+                    elseif result.name then
+                        if result.name:find(i) then
+                            return true
+                        end
+                    end
+                end
+            end
+        end
+    elseif data.raw["recipe"][recipe.name].expensive then
+        if data.raw["recipe"][recipe.name].expensive.result then
+            for _, i in pairs(searchterms) do
+                if recipe.result:find(i) then
+                    return true
+                end
+            end
+        elseif data.raw["recipe"][recipe.name].expensive.results then
+            for k4, result in pairs(data.raw["recipe"][recipe.name].results) do
+                for _, i in pairs(searchterms) do
+                    if result[1] then
+                        if result[1]:find(i) then
+                            return true
+                        end
+                    elseif result.name then
+                        if result.name:find(i) then
+                            return true
+                        end
+                    end
+                end
+            end
+        end
+    elseif data.raw["recipe"][recipe.name].result then
+        for _, i in pairs(searchterms) do
+            if recipe.result:find(i) then
+                return true
+            end
+        end
+    elseif data.raw["recipe"][recipe.name].results then
+        for k4, result in pairs(data.raw["recipe"][recipe.name].results) do
+            for _, i in pairs(searchterms) do
+                if result[1] then
+                    if result[1]:find(i) then
+                        return true
+                    end
+                elseif result.name then
+                    if result.name:find(i) then
+                        return true
+                    end
+                end
+            end
+        end
+    end
+
+    return false
+end
+
+
 local cc = nil
 local exports = {}
 local setting_searchterms = settings.startup["heat-algo-searchterm"].value
@@ -63,115 +134,13 @@ if settings.startup["heat-algo-mode"].value == "advanced" then
                     if data.raw["recipe"][recipe.name].ingredients then
                         for k3, ingredient in pairs(data.raw["recipe"][recipe.name].ingredients) do
                             if ingredient[1] == data.raw["resource"][resource.name].minable.result then
-                                if data.raw["recipe"][recipe.name].normal then
-                                    if data.raw["recipe"][recipe.name].normal.result then
-                                        for _, i in pairs(searchterms) do
-                                            if recipe.result:find(i) then
-                                                local newRecipe = deriveNewHeatRecipe(recipe)
-                                                if ao_debug then
-                                                    log("Copied Smelting Recipe: " .. newRecipe.name)
-                                                end
-                                                --data:extend({ newRecipe })
-                                                table.insert(exports, newRecipe)
-                                            end
-                                        end
-                                    elseif data.raw["recipe"][recipe.name].normal.results then
-                                        for k4, result in pairs(data.raw["recipe"][recipe.name].results) do
-                                            for _, i in pairs(searchterms) do
-                                                if result[1] then
-                                                    if result[1]:find(i) then
-                                                        local newRecipe = deriveNewHeatRecipe(recipe)
-                                                        if ao_debug then
-                                                            log("Copied Smelting Recipe: " .. newRecipe.name)
-                                                        end
-                                                        --data:extend({ newRecipe })
-                                                        table.insert(exports, newRecipe)
-                                                    end
-                                                elseif result.name then
-                                                    if result.name:find(i) then
-                                                        local newRecipe = deriveNewHeatRecipe(recipe)
-                                                        if ao_debug then
-                                                            log("Copied Smelting Recipe: " .. newRecipe.name)
-                                                        end
-                                                        --data:extend({ newRecipe })
-                                                        table.insert(exports, newRecipe)
-                                                    end
-                                                end
-                                            end
-                                        end
+                                if recipeProductMatchesSearchterms(recipe, searchterms) then
+                                    local newRecipe = deriveNewHeatRecipe(recipe)
+                                    if ao_debug then
+                                        log("Copied Smelting Recipe: " .. newRecipe.name)
                                     end
-                                elseif data.raw["recipe"][recipe.name].expensive then
-                                    if data.raw["recipe"][recipe.name].expensive.result then
-                                        for _, i in pairs(searchterms) do
-                                            if recipe.result:find(i) then
-                                                local newRecipe = deriveNewHeatRecipe(recipe)
-                                                if ao_debug then
-                                                    log("Copied Smelting Recipe: " .. newRecipe.name)
-                                                end
-                                                --data:extend({ newRecipe })
-                                                table.insert(exports, newRecipe)
-                                            end
-                                        end
-                                    elseif data.raw["recipe"][recipe.name].expensive.results then
-                                        for k4, result in pairs(data.raw["recipe"][recipe.name].results) do
-                                            for _, i in pairs(searchterms) do
-                                                if result[1] then
-                                                    if result[1]:find(i) then
-                                                        local newRecipe = deriveNewHeatRecipe(recipe)
-                                                        if ao_debug then
-                                                            log("Copied Smelting Recipe: " .. newRecipe.name)
-                                                        end
-                                                        --data:extend({ newRecipe })
-                                                        table.insert(exports, newRecipe)
-                                                    end
-                                                elseif result.name then
-                                                    if result.name:find(i) then
-                                                        local newRecipe = deriveNewHeatRecipe(recipe)
-                                                        if ao_debug then
-                                                            log("Copied Smelting Recipe: " .. newRecipe.name)
-                                                        end
-                                                        --data:extend({ newRecipe })
-                                                        table.insert(exports, newRecipe)
-                                                    end
-                                                end
-                                            end
-                                        end
-                                    end
-                                elseif data.raw["recipe"][recipe.name].result then
-                                    for _, i in pairs(searchterms) do
-                                        if recipe.result:find(i) then
-                                            local newRecipe = deriveNewHeatRecipe(recipe)
-                                            if ao_debug then
-                                                log("Copied Smelting Recipe: " .. newRecipe.name)
-                                            end
-                                            --data:extend({ newRecipe })
-                                            table.insert(exports, newRecipe)
-                                        end
-                                    end
-                                elseif data.raw["recipe"][recipe.name].results then
-                                    for k4, result in pairs(data.raw["recipe"][recipe.name].results) do
-                                        for _, i in pairs(searchterms) do
-                                            if result[1] then
-                                                if result[1]:find(i) then
-                                                    local newRecipe = deriveNewHeatRecipe(recipe)
-                                                    if ao_debug then
-                                                        log("Copied Smelting Recipe: " .. newRecipe.name)
-                                                    end
-                                                    --data:extend({ newRecipe })
-                                                    table.insert(exports, newRecipe)
-                                                end
-                                            elseif result.name then
-                                                if result.name:find(i) then
-                                                    local newRecipe = deriveNewHeatRecipe(recipe)
-                                                    if ao_debug then
-                                                        log("Copied Smelting Recipe: " .. newRecipe.name)
-                                                    end
-                                                    --data:extend({ newRecipe })
-                                                    table.insert(exports, newRecipe)
-                                                end
-                                            end
-                                        end
-                                    end
+                                    --data:extend({ newRecipe })
+                                    table.insert(exports, newRecipe)
                                 end
                             end
                         end

--- a/prototypes/recipes/plate-heat-recipe.lua
+++ b/prototypes/recipes/plate-heat-recipe.lua
@@ -36,16 +36,11 @@ local function productMatchesSearchterms(recipeData, searchterms)
             end
         end
     elseif recipeData.results then
-        for k4, result in pairs(recipeData.results) do
+        for _, result in pairs(recipeData.results) do
             for _, i in pairs(searchterms) do
-                if result[1] then
-                    if result[1]:find(i) then
-                        return true
-                    end
-                elseif result.name then
-                    if result.name:find(i) then
-                        return true
-                    end
+                if (result[1] and result[1]:find(i)) or
+                    (result.name and result.name:find(i)) then
+                    return true
                 end
             end
         end
@@ -55,15 +50,12 @@ local function productMatchesSearchterms(recipeData, searchterms)
 end
 
 local function recipeProductMatchesSearchterms(recipe, searchterms)
-    if recipe.normal then
-        return productMatchesSearchterms(recipe.normal, searchterms)
-    elseif recipe.expensive then
-        return productMatchesSearchterms(recipe.expensive, searchterms)
-    elseif recipe then
-        return productMatchesSearchterms(recipe, searchterms)
-    end
-
-    return false
+    return
+        recipe and (
+            productMatchesSearchterms(recipe.normal, searchterms) or
+            productMatchesSearchterms(recipe.expensive, searchterms) or
+            productMatchesSearchterms(recipe, searchterms)
+        )
 end
 
 

--- a/settings.lua
+++ b/settings.lua
@@ -50,6 +50,7 @@ data:extend({
         name = "heat-algo-searchterm",
         setting_type = "startup",
         default_value = "plate, brick",
+        allow_blank = true,
         order = "g"
     },
     {


### PR DESCRIPTION
Hi there,

I like your mod ... however the heat furnace did not work at all with brevven's mods (bztitanium, bzcarbon, ...).  It was missing all recipes (aluminum plate, tin plate, to name a few).

I looked at the source and tried to understand your recipe deriving algorithm.  While doing that I refactored it, so I could understand it.  The result is in this PR in the hope that you find it useful.  Your source had a lot of code duplication I managed to reduce it by three quarters!  Don't be afraid by the number of commits, most commits are very small and usually do only one thing.  I don't recount what they do, please see the individual commit messages for that.

While doing the refactor I also fixed some bugs lurking in the code, e.g. handle all cases of `normal`, `expensive` ingredients, results, check both `abc.name` and `abc[1]` for the name of the item/recipe/ingredient, etc.

Beyond that I altered the algorithm in the following way (which might or might not count as bugs):

-  bef7d2fecac07c86abf6cfbe286b5e8f4d44a7f1 : Do not modify the `hidden` or `enabled` attribute of recipes.  The recipe in question should already be set up properly.  Also note that those attributes can be in three different locations (like ingredients), so setting them requires some code!
- c25080504baa57dca113aa21c95eccc12a66e910 : the basic variant of the algorithm also checks `expensive` recipes (previously they were ignored)
- a596677e7b608ea8fd0d9cbf8150ef17a1da900b : Support resources with multiple results (not sure if this was an oversight or intentional)
-  9881197a8a85e5585c732641937c54441bbf9325 , 7d1d7d51e2c42cbb0e3b50dc69b9fc6a0ccd94b3 : Allow the empty string as algorithm search keyword.  An empty string is interpreted as "match any recipe".  With this we can set the algorithm keywords to "" (empty) and the algorithm mode to basic and then *all* smelting recipes get duplicated for the heat furnace. (A good default in my opinion as the heat furnace is now a drop in for the steel furnace, but that is your decision to make.)
\
I also added a changelog entry for this as that is something the users might be interested in knowing.  Also note that I elaborated this in the tool tip explanation, so this probably needs some retranslation by your translators.

- a414263f08c70834870c22c0d97f8b45b3bb9065 , a9aff8ca971d99f9d52cde525757ed37bc436d5e : As mentioned above, I play with brevven's mod an also bismuth.  They do modify some smelting recipes in their data-final-fixes phase.  To properly copy these recipes our data-final-fixes.lua must run after theirs.  The easiest way to ensure this is making those mods a (hidden) optional dependency.
\
In my test this also had the side effect that now our graphite item "wins" the data phase race resulting in changed graphics (previously they won because **A**tomic_Overhaul comes before **b**zcarbon).  To mitigate this, I modified our graphite item to be only added if there is not already one.  (This seems to be good practice anyway).

Have fun!