### PR TITLE
Complexity Full: MOX fuel cell are made in the centrifuge

### DIFF
--- a/prototypes/recipes/MOX-fuel-cell-recipe.lua
+++ b/prototypes/recipes/MOX-fuel-cell-recipe.lua
@@ -1,7 +1,9 @@
 local m_ingredients
 local m_results
 local m_time
+local m_category
 if settings.startup["ao-complexity-level"].value == "simple" then
+    m_category = "crafting"
     m_ingredients =
     {
         { "plutonium",   4 },
@@ -13,6 +15,7 @@ if settings.startup["ao-complexity-level"].value == "simple" then
     }
     m_time = 75
 else
+    m_category = "centrifuging"
     m_ingredients =
     {
         { "MOX-fuel-rod",    10 },
@@ -32,7 +35,7 @@ data:extend(
             icon = graphics .. "MOX-fuel-cell.png",
             icon_size = 64,
             icon_mipmaps = 4,
-            -- category = "centrifuging",
+            category = m_category,
             crafting_machine_tint = cmt.MOX,
             energy_required = m_time,
             enabled = false,


### PR DESCRIPTION
With full complexity the MOX fuel cell are made in the centrifuge like any other fuel cell.

Since the MOX cell is the only one not made in a centrifuge, this looks like an oversight while simplifying the process in https://github.com/Xman1109/Atomic_Overhaul/commit/414fbcc7bb820ce776723d880dc3690c5abdb980 (and at least was very surprising for me).