### PR TITLE
Quick-Fix of migrations 1.0.5 and 1.3.0

### DIFF
--- a/migrations/1.0.5.lua
+++ b/migrations/1.0.5.lua
@@ -5,8 +5,12 @@ for index, force in pairs(game.forces) do
 
     else
         if technologies["uranium-processing"].researched then
-            technologies["ao-graphite-processing"].researched = true
-            technologies["graphite-fuel-reprocessing"].researched = true
+            if technologies["ao-graphite-processing"] then
+                technologies["ao-graphite-processing"].researched = true
+            end
+            if technologies["graphite-processing"] then
+                technologies["graphite-fuel-reprocessing"].researched = true
+            end
         end
         if technologies["plutonium-processing"].researched then
             technologies["MOX-processing"].researched = true

--- a/migrations/1.3.0.lua
+++ b/migrations/1.3.0.lua
@@ -21,14 +21,22 @@ for index, force in pairs(game.forces) do
             recipe["heat-furnace-recipe"].enabled = true
         end
         if settings.startup["ao-complexity-level"].value ~= "simple" then
-            recipe["graphite-fuel-cell-recipe"].enabled = false
-            recipe["graphite-fuel-reprocessing"].enabled = false
-            recipe["graphite-recipe"].enabled = false
+            if recipe["graphite-fuel-cell-recipe"] then
+                recipe["graphite-fuel-cell-recipe"].enabled = false
+            end
+            if recipe["graphite-fuel-reprocessing"] then
+                recipe["graphite-fuel-reprocessing"].enabled = false
+            end
+            if recipe["graphite-recipe"] then
+                recipe["graphite-recipe"].enabled = false
+            end
 
-            technologies["ao-graphite-processing"].researched = false
-            technologies["graphite-fuel-reprocessing"].researched = false
-            technologies["ao-graphite-processing"].enabled = false
-            technologies["graphite-fuel-reprocessing"].enabled = false
+            if technologies["ao-graphite-processing"] and technologies["graphite-processing"] then
+                technologies["ao-graphite-processing"].researched = false
+                technologies["graphite-fuel-reprocessing"].researched = false
+                technologies["ao-graphite-processing"].enabled = false
+                technologies["graphite-fuel-reprocessing"].enabled = false
+            end
         end
     end
 end


### PR DESCRIPTION
Adding *Atomic Overhaul (version 1.3.34)* to an existing Factorio 2.0 Space Age game causes several errors due to migrations accessing non-existing recipes and technologies.

As far as I could quickly figure out, these issues are all related to the removal of the graphite feature later on, so these recipes and technologies do not exist anymore.

All I did was checking for the existence of the accessed recipes and technologies, before they are accessed.
There might be a better approach, but I'm not familiar with this code base. This fix solved my issues though, so for your convenience I'm sharing these as a pull request with you.

If you have any incentive to fix older versions of the mod for any reason, e.g. to still support older versions of Factorio, as far as I can tell, you should be able to apply those 2 commits to either 1.0.5 and 1.3.0 respectively, or to the version in which the graphite related features were removed, without causing any issues.